### PR TITLE
Subcommands now show binary as cargo-checkmate-SUBCOMMAND

### DIFF
--- a/src/options.rs
+++ b/src/options.rs
@@ -43,7 +43,11 @@ impl Options {
             it.next();
         }
 
-        Options::from_iter(it)
+        Self::from_clap(
+            &Self::clap()
+                .bin_name("cargo-checkmate")
+                .get_matches_from(it),
+        )
     }
 }
 


### PR DESCRIPTION
Fixes #23... Sort of. Clap expects the subcommand name to be part of the bin name (it has custom logic to replace whitespace in the binary name with `-`s, with the commented example being to rename the subcommand `git mv` as `git-mv`).

That said, I've gotten it so that it now lists the binary as `cargo-checkmate-doc` instead of `doc`.